### PR TITLE
Fix type export, quick and dirty

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,17 @@
   "main": "lib/SVGPathData.cjs",
   "module": "lib/SVGPathData.module.js",
   "exports": {
-    "import": "./lib/SVGPathData.module.js",
-    "require": "./lib/SVGPathData.cjs"
+    ".": {
+      "import": "./lib/SVGPathData.module.js",
+      "require": "./lib/SVGPathData.cjs",
+      "types": "./lib/SVGPathData.d.ts"
+    },
+    "./lib/types": {
+      "types": "./lib/types.d.ts"
+    }
   },
   "type": "module",
-  "types": "lib/SVGPathData.d.ts",
+  "types": "./lib/SVGPathData.d.ts",
   "scripts": {
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "cli": "env NODE_ENV=${NODE_ENV:-cli}",


### PR DESCRIPTION

### Proposed changes
`skipLibCheck: false` fails in `moduleResolution: Bundler` without this. Submitting a separate PR from https://github.com/nfroidure/svg-pathdata/pull/67 because I assume this has higher chances of being merged and released quickly.


### Code quality
- [ ] I made some tests for my changes
- [ ] I added my name in the [contributors](https://docs.npmjs.com/files/package.json#people-fields-author-contributors) field of the package.json file

### License
To get your contribution merged, you must check the following.

- [x] I read the project license in the LICENSE file
- [x] I agree with publishing under this project license
