### PR TITLE
chore: remove yerror from dependencies and use jest.expect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "svg-pathdata",
       "version": "7.1.0",
       "license": "MIT",
-      "dependencies": {
-        "yerror": "^8.0.0"
-      },
       "devDependencies": {
         "@eslint/js": "^9.7.0",
         "@swc/cli": "^0.4.0",
@@ -10327,6 +10324,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/yerror/-/yerror-8.0.0.tgz",
       "integrity": "sha512-FemWD5/UqNm8ffj8oZIbjWXIF2KE0mZssggYpdaQkWDDgXBQ/35PNIxEuz6/YLn9o0kOxDBNJe8x8k9ljD7k/g==",
+      "dev": true,
       "engines": {
         "node": ">=18.16.0"
       }

--- a/package.json
+++ b/package.json
@@ -142,9 +142,6 @@
     "trailingComma": "all",
     "proseWrap": "always"
   },
-  "dependencies": {
-    "yerror": "^8.0.0"
-  },
   "jest": {
     "coverageReporters": [
       "lcov"

--- a/src/tests/testUtils.ts
+++ b/src/tests/testUtils.ts
@@ -1,16 +1,7 @@
 import { expect } from '@jest/globals';
-import { YError } from 'yerror';
 
-export function assertThrows<T>(
-  fn: () => void,
-  type: T,
-  message: string,
-) {
-  try {
-    fn();
-    throw new YError('E_UNEXPECTED_SUCCESS');
-  } catch (err) {
-    expect(err).toBeInstanceOf(type);
-    expect((err as Error).message).toEqual(message);
-  }
+export function assertThrows<T>(fn: () => void, type: T, message: string) {
+  const expRes = expect(fn);
+  expRes.toThrowError(message);
+  expRes.toThrow(type);
 }


### PR DESCRIPTION
reasoning, i'm having hard time actually running tests locally,

```
 ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,jest){import os from 'os';
                                                                                      ^^^^^^

    SyntaxError: Cannot use import statement outside a module

      10 |     fn();
      11 |     throw new YError('E_UNEXPECTED_SUCCESS');
    > 12 |   } catch (err) {
```

### Proposed changes
- removes dependency used only for testing from dependencies and leverages jest build-in error testing

this could be further simplified as this helper is not really needed, 

```
expect(() => yourCode).toThrow(new ErrorType('your message'))
```

### Code quality
- [x] ~I made some tests for my changes~

### License
To get your contribution merged, you must check the following.

- [x] I read the project license in the LICENSE file
- [x] I agree with publishing under this project license
